### PR TITLE
Fix for recent language changes: os.Error -> error

### DIFF
--- a/serial.go
+++ b/serial.go
@@ -55,10 +55,7 @@ Example usage:
 */
 package serial
 
-import (
-	"io"
-	"os"
-)
+import "io"
 
 // Config contains the information needed to open a serial port.
 //
@@ -91,7 +88,7 @@ type Config struct {
 }
 
 // OpenPort opens a serial port with the specified configuration
-func OpenPort(c *Config) (io.ReadWriteCloser, os.Error) {
+func OpenPort(c *Config) (io.ReadWriteCloser, error) {
 	return openPort(c.Name, c.Baud)
 }
 

--- a/serial_darwin.go
+++ b/serial_darwin.go
@@ -6,14 +6,15 @@ import "C"
 // TODO: Maybe change to using syscall package + ioctl instead of cgo
 
 import (
-	"os"
-	"io"
+	"errors"
 	"fmt"
+	"io"
+	"os"
 	"syscall"
 	//"unsafe"
 )
 
-func openPort(name string, baud int) (rwc io.ReadWriteCloser, err os.Error) {
+func openPort(name string, baud int) (rwc io.ReadWriteCloser, err error) {
 	f, err := os.OpenFile(name, os.O_RDWR|os.O_NOCTTY|os.O_NONBLOCK, 0666)
 	if err != nil {
 		return
@@ -22,7 +23,7 @@ func openPort(name string, baud int) (rwc io.ReadWriteCloser, err os.Error) {
 	fd := C.int(f.Fd())
 	if C.isatty(fd) != 1 {
 		f.Close()
-		return nil, os.NewError("File is not a tty")
+		return nil, errors.New("File is not a tty")
 	}
 
 	var st C.struct_termios
@@ -82,7 +83,7 @@ func openPort(name string, baud int) (rwc io.ReadWriteCloser, err os.Error) {
 	if e != 0 || r1 != 0 {
 		s := fmt.Sprint("Clearing NONBLOCK syscall error:", e, r1)
 		f.Close()
-		return nil, os.NewError(s)
+		return nil, errors.New(s)
 	}
 
 	/*


### PR DESCRIPTION
This fixes the replacement of os.Error by error in recent weekly snapshots. Additionally, the third return value of syscall.Syscall is now an error instead of a numeric code.
