### PR TITLE
Adding some serial configuration options

### DIFF
--- a/basic_test.go
+++ b/basic_test.go
@@ -1,4 +1,4 @@
-package serial
+package goserial
 
 import (
 	"testing"

--- a/serial.go
+++ b/serial.go
@@ -16,10 +16,10 @@ connection.  Read() will block until at least one byte is returned.
 Write is the same.  There is currently no exposed way to set the
 timeouts, though patches are welcome.
 
-Currently all ports are opened with 8 data bits, 1 stop bit, no
-parity, no hardware flow control, and no software flow control.  This
-works fine for many real devices and many faux serial devices
-including usb-to-serial converters and bluetooth serial ports.
+Currently ports are opened with 8 data bits, 1 stop bit, no parity, no hardware
+flow control, and no software flow control by default.  This works fine for
+many real devices and many faux serial devices including usb-to-serial
+converters and bluetooth serial ports.
 
 You may Read() and Write() simulantiously on the same connection (from
 different goroutines).

--- a/serial.go
+++ b/serial.go
@@ -92,15 +92,15 @@ type Config struct {
 	Name string
 	Baud int
 
-	Size     int        // 0 get translated to 8 TODO Windows support.
-	Parity   ParityMode // TODO Windows support.
-	StopBits int        // 0 (default) and 1 means 1 stop bit, 2 means 2 stop bits. TODO Windows support.
+	Size     int // 0 get translated to 8
+	Parity   ParityMode
+	StopBits int // 0 (default) and 1 means 1 stop bit, 2 means 2 stop bits
 
 	// RTSFlowControl bool
 	// DTRFlowControl bool
 	// XONFlowControl bool
 
-	CRLFTranslate bool // TODO Windows support.
+	CRLFTranslate bool // Ignored on Windows.
 	// TimeoutStuff int
 }
 

--- a/serial_posix.go
+++ b/serial_posix.go
@@ -80,13 +80,13 @@ func openPort(name string, c *Config) (rwc io.ReadWriteCloser, err error) {
 	// Select character size
 	st.c_cflag &^= C.CSIZE
 	switch c.Size {
-	case 5:
+	case Byte5:
 		st.c_cflag |= C.CS5
-	case 6:
+	case Byte6:
 		st.c_cflag |= C.CS6
-	case 7:
+	case Byte7:
 		st.c_cflag |= C.CS7
-	case 8:
+	case Byte8:
 		st.c_cflag |= C.CS8
 	default:
 		panic(c.Size)

--- a/serial_posix.go
+++ b/serial_posix.go
@@ -1,6 +1,6 @@
 // +build !windows
 
-package serial
+package goserial
 
 // #include <termios.h>
 // #include <unistd.h>
@@ -17,26 +17,30 @@ import (
 	//"unsafe"
 )
 
-func openPort(name string, baud int) (rwc io.ReadWriteCloser, err error) {
+func openPort(name string, c *Config) (rwc io.ReadWriteCloser, err error) {
 	f, err := os.OpenFile(name, syscall.O_RDWR|syscall.O_NOCTTY|syscall.O_NONBLOCK, 0666)
 	if err != nil {
 		return
 	}
 
+	defer func() {
+		if err != nil {
+			f.Close()
+		}
+	}()
+
 	fd := C.int(f.Fd())
 	if C.isatty(fd) != 1 {
-		f.Close()
 		return nil, errors.New("File is not a tty")
 	}
 
 	var st C.struct_termios
 	_, err = C.tcgetattr(fd, &st)
 	if err != nil {
-		f.Close()
 		return nil, err
 	}
 	var speed C.speed_t
-	switch baud {
+	switch c.Baud {
 	case 115200:
 		speed = C.B115200
 	case 57600:
@@ -48,31 +52,85 @@ func openPort(name string, baud int) (rwc io.ReadWriteCloser, err error) {
 	case 9600:
 		speed = C.B9600
 	default:
-		f.Close()
-		return nil, fmt.Errorf("Unknown baud rate %v", baud)
+		return nil, fmt.Errorf("Unknown baud rate %v", c.Baud)
 	}
 
 	_, err = C.cfsetispeed(&st, speed)
 	if err != nil {
-		f.Close()
 		return nil, err
 	}
 	_, err = C.cfsetospeed(&st, speed)
 	if err != nil {
-		f.Close()
 		return nil, err
 	}
 
 	// Select local mode
-	st.c_cflag |= (C.CLOCAL | C.CREAD)
+	st.c_cflag |= C.CLOCAL | C.CREAD
+
+	// Select stop bits
+	if stopBits, err := c.stopBits(); err != nil {
+		return nil, err
+	} else {
+		switch stopBits {
+		case 1:
+			st.c_cflag &^= C.CSTOPB
+		case 2:
+			st.c_cflag |= C.CSTOPB
+		default:
+			panic(stopBits)
+		}
+	}
+
+	// Select character size
+	st.c_cflag &^= C.CSIZE
+	if size, err := c.size(); err != nil {
+		return nil, err
+	} else {
+		switch size {
+		case 5:
+			st.c_cflag |= C.CS5
+		case 6:
+			st.c_cflag |= C.CS6
+		case 7:
+			st.c_cflag |= C.CS7
+		case 8:
+			st.c_cflag |= C.CS8
+		default:
+			panic(size)
+		}
+	}
+
+	// Select parity mode
+	if err = c.checkParityMode(); err != nil {
+		return nil, err
+	} else {
+		switch c.Parity {
+		case ParityNone:
+			st.c_cflag &^= C.PARENB
+		case ParityEven:
+			st.c_cflag |= C.PARENB
+			st.c_cflag &^= C.PARODD
+		case ParityOdd:
+			st.c_cflag |= C.PARENB
+			st.c_cflag |= C.PARODD
+		default:
+			panic(c.Parity)
+		}
+	}
+
+	// Select CRLF translation
+	if c.CRLFTranslate {
+		st.c_iflag |= C.ICRNL
+	} else {
+		st.c_iflag &^= C.ICRNL
+	}
 
 	// Select raw mode
-	st.c_lflag &= ^C.tcflag_t(C.ICANON | C.ECHO | C.ECHOE | C.ISIG)
-	st.c_oflag &= ^C.tcflag_t(C.OPOST)
+	st.c_lflag &^= C.ICANON | C.ECHO | C.ECHOE | C.ISIG
+	st.c_oflag &^= C.OPOST
 
 	_, err = C.tcsetattr(fd, C.TCSANOW, &st)
 	if err != nil {
-		f.Close()
 		return nil, err
 	}
 
@@ -83,7 +141,6 @@ func openPort(name string, baud int) (rwc io.ReadWriteCloser, err error) {
 		uintptr(0))
 	if e != 0 || r1 != 0 {
 		s := fmt.Sprint("Clearing NONBLOCK syscall error:", e, r1)
-		f.Close()
 		return nil, errors.New(s)
 	}
 
@@ -94,7 +151,6 @@ func openPort(name string, baud int) (rwc io.ReadWriteCloser, err error) {
 			                uintptr(unsafe.Pointer(&baud)));
 			        if e != 0 || r1 != 0 {
 			                s := fmt.Sprint("Baudrate syscall error:", e, r1)
-					f.Close()
 		                        return nil, os.NewError(s)
 				}
 	*/

--- a/serial_posix.go
+++ b/serial_posix.go
@@ -68,54 +68,42 @@ func openPort(name string, c *Config) (rwc io.ReadWriteCloser, err error) {
 	st.c_cflag |= C.CLOCAL | C.CREAD
 
 	// Select stop bits
-	if stopBits, err := c.stopBits(); err != nil {
-		return nil, err
-	} else {
-		switch stopBits {
-		case 1:
-			st.c_cflag &^= C.CSTOPB
-		case 2:
-			st.c_cflag |= C.CSTOPB
-		default:
-			panic(stopBits)
-		}
+	switch c.StopBits {
+	case StopBits1:
+		st.c_cflag &^= C.CSTOPB
+	case StopBits2:
+		st.c_cflag |= C.CSTOPB
+	default:
+		panic(c.StopBits)
 	}
 
 	// Select character size
 	st.c_cflag &^= C.CSIZE
-	if size, err := c.size(); err != nil {
-		return nil, err
-	} else {
-		switch size {
-		case 5:
-			st.c_cflag |= C.CS5
-		case 6:
-			st.c_cflag |= C.CS6
-		case 7:
-			st.c_cflag |= C.CS7
-		case 8:
-			st.c_cflag |= C.CS8
-		default:
-			panic(size)
-		}
+	switch c.Size {
+	case 5:
+		st.c_cflag |= C.CS5
+	case 6:
+		st.c_cflag |= C.CS6
+	case 7:
+		st.c_cflag |= C.CS7
+	case 8:
+		st.c_cflag |= C.CS8
+	default:
+		panic(c.Size)
 	}
 
 	// Select parity mode
-	if err = c.checkParityMode(); err != nil {
-		return nil, err
-	} else {
-		switch c.Parity {
-		case ParityNone:
-			st.c_cflag &^= C.PARENB
-		case ParityEven:
-			st.c_cflag |= C.PARENB
-			st.c_cflag &^= C.PARODD
-		case ParityOdd:
-			st.c_cflag |= C.PARENB
-			st.c_cflag |= C.PARODD
-		default:
-			panic(c.Parity)
-		}
+	switch c.Parity {
+	case ParityNone:
+		st.c_cflag &^= C.PARENB
+	case ParityEven:
+		st.c_cflag |= C.PARENB
+		st.c_cflag &^= C.PARODD
+	case ParityOdd:
+		st.c_cflag |= C.PARENB
+		st.c_cflag |= C.PARODD
+	default:
+		panic(c.Parity)
 	}
 
 	// Select CRLF translation

--- a/serial_windows.go
+++ b/serial_windows.go
@@ -1,6 +1,6 @@
 // +build windows
 
-package serial
+package goserial
 
 import (
 	"fmt"
@@ -37,7 +37,7 @@ type structTimeouts struct {
 	WriteTotalTimeoutConstant   uint32
 }
 
-func openPort(name string, baud int) (rwc io.ReadWriteCloser, err error) {
+func openPort(name string, c *Config) (rwc io.ReadWriteCloser, err error) {
 	if len(name) > 0 && name[0] != '\\' {
 		name = "\\\\.\\" + name
 	}
@@ -59,7 +59,7 @@ func openPort(name string, baud int) (rwc io.ReadWriteCloser, err error) {
 		}
 	}()
 
-	if err = setCommState(h, baud); err != nil {
+	if err = setCommState(h, c.Baud); err != nil {
 		return
 	}
 	if err = setupComm(h, 64, 64); err != nil {

--- a/serial_windows.go
+++ b/serial_windows.go
@@ -171,31 +171,39 @@ func setCommState(h syscall.Handle, c *Config) error {
 	params.BaudRate = uint32(baud)
 
 	// Select byte size.
-	if _, err := c.size(); err != nil {
-		return err
+	switch c.Size {
+	case Byte5:
+		params.ByteSize = 5
+	case Byte6:
+		params.ByteSize = 6
+	case Byte7:
+		params.ByteSize = 7
+	case Byte8:
+		params.ByteSize = 8
+	default:
+		panic(c.Size)
 	}
-	params.ByteSize = byte(c.Size)
 
 	// Select parity mode.
-	if parity, err := c.parity(); err != nil {
-		return err
-	} else switch parity {
+	switch c.Parity {
 	case ParityNone:
 		params.Parity = 0
 	case ParityEven:
 		params.Parity = 2
 	case ParityOdd:
 		params.Parity = 1
+	default:
+		panic(c.Parity)
 	}
 
 	// Selet stop bits.
-	if stopBits, err := c.stopBits(); err != nil {
-		return err
-	} else switch stopBits {
-	case 1:
+	switch c.StopBits {
+	case StopBits1:
 		params.StopBits = 0
-	case 2:
+	case StopBits2:
 		params.StopBits = 2
+	default:
+		panic(c.StopBits)
 	}
 
 	r, _, err := syscall.Syscall(nSetCommState, 2, uintptr(h), uintptr(unsafe.Pointer(&params)), 0)


### PR DESCRIPTION
The other change in here, which I can understand if you'd rather that I reverted, is changing the package name from "serial" to "goserial" to meet normal Go package naming conventions (i.e package named after last directory component).