### PR TITLE
I actually want blocking semantics!

### DIFF
--- a/serial_linux.go
+++ b/serial_linux.go
@@ -50,7 +50,7 @@ func openPort(name string, baud int) (rwc io.ReadWriteCloser, err error) {
 		return
 	}
 
-	f, err := os.OpenFile(name, syscall.O_RDWR|syscall.O_NOCTTY|syscall.O_NONBLOCK, 0666)
+	f, err := os.OpenFile(name, syscall.O_RDWR|syscall.O_NOCTTY, 0666)
 	if err != nil {
 		return nil, err
 	}
@@ -80,10 +80,6 @@ func openPort(name string, baud int) (rwc io.ReadWriteCloser, err error) {
 		0,
 	); errno != 0 {
 		return nil, errno
-	}
-
-	if err = syscall.SetNonblock(int(fd), false); err != nil {
-		return
 	}
 
 	return f, nil

--- a/serial_posix.go
+++ b/serial_posix.go
@@ -14,11 +14,10 @@ import (
 	"io"
 	"os"
 	"syscall"
-	//"unsafe"
 )
 
 func openPort(name string, baud int) (rwc io.ReadWriteCloser, err error) {
-	f, err := os.OpenFile(name, syscall.O_RDWR|syscall.O_NOCTTY|syscall.O_NONBLOCK, 0666)
+	f, err := os.OpenFile(name, syscall.O_RDWR|syscall.O_NOCTTY, 0666)
 	if err != nil {
 		return
 	}
@@ -79,29 +78,6 @@ func openPort(name string, baud int) (rwc io.ReadWriteCloser, err error) {
 		f.Close()
 		return nil, err
 	}
-
-	//fmt.Println("Tweaking", name)
-	r1, _, e := syscall.Syscall(syscall.SYS_FCNTL,
-		uintptr(f.Fd()),
-		uintptr(syscall.F_SETFL),
-		uintptr(0))
-	if e != 0 || r1 != 0 {
-		s := fmt.Sprint("Clearing NONBLOCK syscall error:", e, r1)
-		f.Close()
-		return nil, errors.New(s)
-	}
-
-	/*
-				r1, _, e = syscall.Syscall(syscall.SYS_IOCTL,
-			                uintptr(f.Fd()),
-			                uintptr(0x80045402), // IOSSIOSPEED
-			                uintptr(unsafe.Pointer(&baud)));
-			        if e != 0 || r1 != 0 {
-			                s := fmt.Sprint("Baudrate syscall error:", e, r1)
-					f.Close()
-		                        return nil, os.NewError(s)
-				}
-	*/
 
 	return f, nil
 }


### PR DESCRIPTION
I made a small modification to remove the nonblock flags and calls from the darwin and linux.

I was writing a simple protocol that does line back and forward, and didn't want to spend a bunch of effort on flow control.

Instead of that I just removed the non-blocking behavior so that I could easily stall on write and read at an appropriate rate.

Totally happy if this doesn't fit your use case and you just want to close out.
