### PR TITLE
Better handling of Darwin/OS X

### DIFF
--- a/serial_darwin.go
+++ b/serial_darwin.go
@@ -43,13 +43,20 @@ func openPort(name string, baud int) (rwc io.ReadWriteCloser, err error) {
 	}
 
 	// These are mostly torn out of the pyserial implementation
+	// Clear char-size, stop-bits, even and odd parity as well as xon/xoff
 	t.Cflag &^= (syscall.CSIZE | syscall.CSTOPB | syscall.PARENB | syscall.PARODD | syscall.IXON | syscall.IXOFF)
+	// Ignore modem control lines, enable receiver, 8-bit char-size
 	t.Cflag |= (syscall.CLOCAL | syscall.CREAD | syscall.CS8)
+	// Disable canonical mode, echo, echo erase, echo kill, echo newline, signal on INTR/QUIT/SUSP/DSUSP characters, impl. defined input processing
 	t.Lflag &^= (syscall.ICANON | syscall.ECHO | syscall.ECHOE | syscall.ECHOK | syscall.ECHONL | syscall.ISIG | syscall.IEXTEN)
+	// Disable impl. defined output processing
 	t.Oflag &^= (syscall.OPOST)
+	// Disable NL->CR translation, carriage-return ignore, CR->NL translation, break ignore
 	t.Iflag &^= (syscall.INLCR | syscall.IGNCR | syscall.ICRNL | syscall.IGNBRK)
 
+	// Minimum bytes for read
 	t.Cc[syscall.VMIN] = 1
+	// Timeout in deciseconds
 	t.Cc[syscall.VTIME] = 30
 
 	// Apply flags

--- a/serial_darwin.go
+++ b/serial_darwin.go
@@ -9,6 +9,7 @@ import (
 	"unsafe"
 )
 
+// Darwin specific IOCTL constants
 const (
 	IOSSIOSPEED = 0x80045402 // _IOW('T', 2, speed_t)
 )
@@ -44,15 +45,15 @@ func openPort(name string, baud int) (rwc io.ReadWriteCloser, err error) {
 
 	// These are mostly torn out of the pyserial implementation
 	// Clear char-size, stop-bits, even and odd parity as well as xon/xoff
-	t.Cflag &^= (syscall.CSIZE | syscall.CSTOPB | syscall.PARENB | syscall.PARODD | syscall.IXON | syscall.IXOFF)
+	t.Cflag &^= (syscall.CSIZE | syscall.CSTOPB | syscall.PARENB | syscall.PARODD | syscall.IXANY | syscall.IXON | syscall.IXOFF)
 	// Ignore modem control lines, enable receiver, 8-bit char-size
 	t.Cflag |= (syscall.CLOCAL | syscall.CREAD | syscall.CS8)
 	// Disable canonical mode, echo, echo erase, echo kill, echo newline, signal on INTR/QUIT/SUSP/DSUSP characters, impl. defined input processing
 	t.Lflag &^= (syscall.ICANON | syscall.ECHO | syscall.ECHOE | syscall.ECHOK | syscall.ECHONL | syscall.ISIG | syscall.IEXTEN)
 	// Disable impl. defined output processing
 	t.Oflag &^= (syscall.OPOST)
-	// Disable NL->CR translation, carriage-return ignore, CR->NL translation, break ignore
-	t.Iflag &^= (syscall.INLCR | syscall.IGNCR | syscall.ICRNL | syscall.IGNBRK)
+	// Disable parity error marking, input parity checking, strip eighth bit, NL->CR translation, carriage-return ignore, CR->NL translation, break ignore
+	t.Iflag &^= (syscall.PARMRK | syscall.INPCK | syscall.ISTRIP | syscall.INLCR | syscall.IGNCR | syscall.ICRNL | syscall.IGNBRK)
 
 	// Minimum bytes for read
 	t.Cc[syscall.VMIN] = 1

--- a/serial_darwin.go
+++ b/serial_darwin.go
@@ -1,0 +1,86 @@
+// +build darwin
+
+package serial
+
+import (
+	"io"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+const (
+	IOSSIOSPEED = 0x80045402 // _IOW('T', 2, speed_t)
+)
+
+func openPort(name string, baud int) (rwc io.ReadWriteCloser, err error) {
+	f, err := os.OpenFile(name, syscall.O_RDWR|syscall.O_NOCTTY|syscall.O_NONBLOCK, 0666)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		if err != nil && f != nil {
+			f.Close()
+		}
+	}()
+
+	fd := f.Fd()
+
+	t := &syscall.Termios{}
+
+	// Fetch old flags
+	if _, _, errno := syscall.Syscall6(
+		syscall.SYS_IOCTL,
+		uintptr(fd),
+		uintptr(syscall.TIOCGETA),
+		uintptr(unsafe.Pointer(t)),
+		0,
+		0,
+		0,
+	); errno != 0 {
+		return nil, errno
+	}
+
+	// These are mostly torn out of the pyserial implementation
+	t.Cflag &^= (syscall.CSIZE | syscall.CSTOPB | syscall.PARENB | syscall.PARODD | syscall.IXON | syscall.IXOFF)
+	t.Cflag |= (syscall.CLOCAL | syscall.CREAD | syscall.CS8)
+	t.Lflag &^= (syscall.ICANON | syscall.ECHO | syscall.ECHOE | syscall.ECHOK | syscall.ECHONL | syscall.ISIG | syscall.IEXTEN)
+	t.Oflag &^= (syscall.OPOST)
+	t.Iflag &^= (syscall.INLCR | syscall.IGNCR | syscall.ICRNL | syscall.IGNBRK)
+
+	t.Cc[syscall.VMIN] = 1
+	t.Cc[syscall.VTIME] = 30
+
+	// Apply flags
+	if _, _, errno := syscall.Syscall6(
+		syscall.SYS_IOCTL,
+		uintptr(fd),
+		uintptr(syscall.TIOCSETA),
+		uintptr(unsafe.Pointer(t)),
+		0,
+		0,
+		0,
+	); errno != 0 {
+		return nil, errno
+	}
+
+	// Set baudrate
+	if _, _, errno := syscall.Syscall6(
+		syscall.SYS_IOCTL,
+		uintptr(fd),
+		IOSSIOSPEED,
+		uintptr(unsafe.Pointer(&baud)),
+		0,
+		0,
+		0,
+	); errno != 0 {
+		return nil, errno
+	}
+
+	if err = syscall.SetNonblock(int(fd), false); err != nil {
+		return
+	}
+
+	return f, nil
+}

--- a/serial_posix.go
+++ b/serial_posix.go
@@ -1,4 +1,4 @@
-// +build !windows,cgo
+// +build !windows,!darwin,cgo
 
 package serial
 


### PR DESCRIPTION
I was experiencing some quite severe difficulties with the "posix" handling on my OS X machines. After a while with a constant 115200baud datastream, the stream would stop, and usbd would have issues with 60% idle load.

I had pyserial in my toolbox which I knew worked just fine on the same machine with same speeds and payloads. So, I took serial_linux.go (The implementation was nicer to my eye), and mangled it so it was closer to pyserial's behaviour, both in flags and how to set baudrate on Darwin (Which happens using a special ioctl for IOKit, instead of the legacy posix approach).

I have now successfully run with a constant payload over several hours without it pausing randomly, while it would usually pause after 5 minutes before. It's not very scientific, but it works, and it's prettier than before. serial_posix.go is maintained for other platforms, but the platform-specific handling should probably be unified at some point, as it boils down to flag availability (Do we have an easy way to detect this?), and baudrate method/availability.
