### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ func main() {
         if err != nil {
                 log.Fatal(err)
         }
-        log.Print("%q", buf[:n])
+        log.Printf("%q", buf[:n])
 }
 ```
 


### PR DESCRIPTION
Changes typo line 58 log.Print(format,value) to log.Printf