### PR TITLE
Adding Flush() to flush serial port I/O buffers

### DIFF
--- a/serial.go
+++ b/serial.go
@@ -118,8 +118,6 @@ func posixTimeoutValues(readTimeout time.Duration) (vmin uint8, vtime uint8) {
 	return minBytesToRead, uint8(readTimeoutInDeci)
 }
 
-// func Flush()
-
 // func SendBreak()
 
 // func RegisterBreakHandler(func())

--- a/serial_linux.go
+++ b/serial_linux.go
@@ -103,6 +103,8 @@ func (p *Port) Write(b []byte) (n int, err error) {
 	return p.f.Write(b)
 }
 
+// Discards data written to the port but not transmitted,
+// or data received but not read
 func (p *Port) Flush() error {
 	const TCFLSH = 0x540B
 	_, _, err := syscall.Syscall(

--- a/serial_linux.go
+++ b/serial_linux.go
@@ -86,13 +86,14 @@ func openPort(name string, baud int, readTimeout time.Duration) (p *Port, err er
 		return
 	}
 
-	return &Port{f: f}, nil
+	return &Port{f: f, fd: fd}, nil
 }
 
 type Port struct {
 	// We intentionly do not use an "embedded" struct so that we
 	// don't export File
-	f *os.File
+	f  *os.File
+	fd uintptr
 }
 
 func (p *Port) Read(b []byte) (n int, err error) {
@@ -101,6 +102,17 @@ func (p *Port) Read(b []byte) (n int, err error) {
 
 func (p *Port) Write(b []byte) (n int, err error) {
 	return p.f.Write(b)
+}
+
+func (p *Port) Flush() error {
+	const TCFLSH = 0x540B
+	_, _, err := syscall.Syscall(
+		syscall.SYS_IOCTL,
+		uintptr(p.fd),
+		uintptr(TCFLSH),
+		uintptr(syscall.TCIOFLUSH),
+	)
+	return err
 }
 
 func (p *Port) Close() (err error) {

--- a/serial_linux.go
+++ b/serial_linux.go
@@ -86,14 +86,13 @@ func openPort(name string, baud int, readTimeout time.Duration) (p *Port, err er
 		return
 	}
 
-	return &Port{f: f, fd: fd}, nil
+	return &Port{f: f}, nil
 }
 
 type Port struct {
 	// We intentionly do not use an "embedded" struct so that we
 	// don't export File
-	f  *os.File
-	fd uintptr
+	f *os.File
 }
 
 func (p *Port) Read(b []byte) (n int, err error) {
@@ -108,7 +107,7 @@ func (p *Port) Flush() error {
 	const TCFLSH = 0x540B
 	_, _, err := syscall.Syscall(
 		syscall.SYS_IOCTL,
-		uintptr(p.fd),
+		uintptr(p.f.Fd()),
 		uintptr(TCFLSH),
 		uintptr(syscall.TCIOFLUSH),
 	)

--- a/serial_posix.go
+++ b/serial_posix.go
@@ -116,14 +116,13 @@ func openPort(name string, baud int, readTimeout time.Duration) (p *Port, err er
 				}
 	*/
 
-	return &Port{f: f, fd: fd}, nil
+	return &Port{f: f}, nil
 }
 
 type Port struct {
 	// We intentionly do not use an "embedded" struct so that we
 	// don't export File
-	f  *os.File
-	fd C.int
+	f *os.File
 }
 
 func (p *Port) Read(b []byte) (n int, err error) {
@@ -135,7 +134,7 @@ func (p *Port) Write(b []byte) (n int, err error) {
 }
 
 func (p *Port) Flush() error {
-	_, err := C.tcflush(p.fd, C.TCIOFLUSH)
+	_, err := C.tcflush(C.int(p.f.Fd()), C.TCIOFLUSH)
 	return err
 }
 

--- a/serial_posix.go
+++ b/serial_posix.go
@@ -116,13 +116,14 @@ func openPort(name string, baud int, readTimeout time.Duration) (p *Port, err er
 				}
 	*/
 
-	return &Port{f: f}, nil
+	return &Port{f: f, fd: fd}, nil
 }
 
 type Port struct {
 	// We intentionly do not use an "embedded" struct so that we
 	// don't export File
-	f *os.File
+	f  *os.File
+	fd C.int
 }
 
 func (p *Port) Read(b []byte) (n int, err error) {
@@ -131,6 +132,11 @@ func (p *Port) Read(b []byte) (n int, err error) {
 
 func (p *Port) Write(b []byte) (n int, err error) {
 	return p.f.Write(b)
+}
+
+func (p *Port) Flush() error {
+	_, err := C.tcflush(p.fd, C.TCIOFLUSH)
+	return err
 }
 
 func (p *Port) Close() (err error) {

--- a/serial_posix.go
+++ b/serial_posix.go
@@ -133,6 +133,8 @@ func (p *Port) Write(b []byte) (n int, err error) {
 	return p.f.Write(b)
 }
 
+// Discards data written to the port but not transmitted,
+// or data received but not read
 func (p *Port) Flush() error {
 	_, err := C.tcflush(C.int(p.f.Fd()), C.TCIOFLUSH)
 	return err

--- a/serial_windows.go
+++ b/serial_windows.go
@@ -127,6 +127,8 @@ func (p *Port) Read(buf []byte) (int, error) {
 	return getOverlappedResult(p.fd, p.ro)
 }
 
+// Discards data written to the port but not transmitted,
+// or data received but not read
 func (p *Port) Flush() error {
 	return purgeComm(p.fd)
 }

--- a/serial_windows.go
+++ b/serial_windows.go
@@ -127,6 +127,10 @@ func (p *Port) Read(buf []byte) (int, error) {
 	return getOverlappedResult(p.fd, p.ro)
 }
 
+func (p *Port) Flush() error {
+	return purgeComm(p.fd)
+}
+
 var (
 	nSetCommState,
 	nSetCommTimeouts,
@@ -134,7 +138,9 @@ var (
 	nSetupComm,
 	nGetOverlappedResult,
 	nCreateEvent,
-	nResetEvent uintptr
+	nResetEvent,
+	nPurgeComm,
+	nFlushFileBuffers uintptr
 )
 
 func init() {
@@ -151,6 +157,8 @@ func init() {
 	nGetOverlappedResult = getProcAddr(k32, "GetOverlappedResult")
 	nCreateEvent = getProcAddr(k32, "CreateEventW")
 	nResetEvent = getProcAddr(k32, "ResetEvent")
+	nPurgeComm = getProcAddr(k32, "PurgeComm")
+	nFlushFileBuffers = getProcAddr(k32, "FlushFileBuffers")
 }
 
 func getProcAddr(lib syscall.Handle, name string) uintptr {
@@ -248,6 +256,19 @@ func setCommMask(h syscall.Handle) error {
 
 func resetEvent(h syscall.Handle) error {
 	r, _, err := syscall.Syscall(nResetEvent, 1, uintptr(h), 0, 0)
+	if r == 0 {
+		return err
+	}
+	return nil
+}
+
+func purgeComm(h syscall.Handle) error {
+	const PURGE_TXABORT = 0x0001
+	const PURGE_RXABORT = 0x0002
+	const PURGE_TXCLEAR = 0x0004
+	const PURGE_RXCLEAR = 0x0008
+	r, _, err := syscall.Syscall(nPurgeComm, 2, uintptr(h),
+		PURGE_TXABORT|PURGE_RXABORT|PURGE_TXCLEAR|PURGE_RXCLEAR, 0)
 	if r == 0 {
 		return err
 	}


### PR DESCRIPTION
- Current implementation will flush both Input and Output buffers
- Added Flush to Windows calling PurgeComm()
- Added Flush to POSIX calling tcflush()
- Added Flush to Linux using syscall IOCTL with TCFLSH
- Tested on Windows, POSIX and Linux environment