### PR TITLE
Introduce interface to allow for replacement when testing

### DIFF
--- a/serial.go
+++ b/serial.go
@@ -56,6 +56,7 @@ Example usage:
 package serial
 
 import (
+	"io"
 	"time"
 )
 
@@ -90,8 +91,19 @@ type Config struct {
 	// CRLFTranslate bool
 }
 
+type Flusher interface {
+	Flush() error
+}
+
+type ReadWriteCloseFlusher interface {
+	io.Reader
+	io.Writer
+	io.Closer
+	Flusher
+}
+
 // OpenPort opens a serial port with the specified configuration
-func OpenPort(c *Config) (*Port, error) {
+func OpenPort(c *Config) (ReadWriteCloseFlusher, error) {
 	return openPort(c.Name, c.Baud, c.ReadTimeout)
 }
 


### PR DESCRIPTION
The change from io.ReadWriteCloser removed the ability to mock the serial connection for testing. By adding a Flusher interface and then extending ReadWriteCloser with it I created a new interface that matches the functionality that the Port structure but allows a fake replacement to be used for testing.