### PR TITLE
Fixed typo in usage code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ func main() {
         }
         
         buf := make([]byte, 128)
-        n, err = s.Read(buf)
+        n, err := s.Read(buf)
         if err != nil {
                 log.Fatal(err)
         }


### PR DESCRIPTION
Colon missing