### PR TITLE
Make Port extend io.Reader/io.Writer/io.Closer to support bufio.Scanner

### DIFF
--- a/serial_linux.go
+++ b/serial_linux.go
@@ -7,7 +7,7 @@ import (
 	"syscall"
 	"time"
 	"unsafe"
-    "io"
+	"io"
 )
 
 func openPort(name string, baud int, readTimeout time.Duration) (p *Port, err error) {
@@ -91,9 +91,9 @@ func openPort(name string, baud int, readTimeout time.Duration) (p *Port, err er
 }
 
 type Port struct {
-    io.Reader
-    io.Writer
-    io.Closer
+	io.Reader
+	io.Writer
+	io.Closer
 	// We intentionly do not use an "embedded" struct so that we
 	// don't export File
 	f *os.File

--- a/serial_linux.go
+++ b/serial_linux.go
@@ -7,6 +7,7 @@ import (
 	"syscall"
 	"time"
 	"unsafe"
+    "io"
 )
 
 func openPort(name string, baud int, readTimeout time.Duration) (p *Port, err error) {
@@ -90,6 +91,9 @@ func openPort(name string, baud int, readTimeout time.Duration) (p *Port, err er
 }
 
 type Port struct {
+    io.Reader
+    io.Writer
+    io.Closer
 	// We intentionly do not use an "embedded" struct so that we
 	// don't export File
 	f *os.File

--- a/serial_posix.go
+++ b/serial_posix.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"syscall"
 	"time"
+    "io"
 	//"unsafe"
 )
 
@@ -120,6 +121,9 @@ func openPort(name string, baud int, readTimeout time.Duration) (p *Port, err er
 }
 
 type Port struct {
+    io.Reader
+    io.Writer
+    io.Closer
 	// We intentionly do not use an "embedded" struct so that we
 	// don't export File
 	f *os.File

--- a/serial_posix.go
+++ b/serial_posix.go
@@ -14,7 +14,7 @@ import (
 	"os"
 	"syscall"
 	"time"
-    "io"
+	"io"
 	//"unsafe"
 )
 
@@ -121,9 +121,9 @@ func openPort(name string, baud int, readTimeout time.Duration) (p *Port, err er
 }
 
 type Port struct {
-    io.Reader
-    io.Writer
-    io.Closer
+	io.Reader
+	io.Writer
+	io.Closer
 	// We intentionly do not use an "embedded" struct so that we
 	// don't export File
 	f *os.File

--- a/serial_windows.go
+++ b/serial_windows.go
@@ -9,13 +9,14 @@ import (
 	"syscall"
 	"time"
 	"unsafe"
-    "io"
+	"io"
 )
 
 type Port struct {
-    io.Reader
-    io.Writer
-    io.Closer
+	io.Reader
+	io.Writer
+	io.Closer
+
 	f  *os.File
 	fd syscall.Handle
 	rl sync.Mutex

--- a/serial_windows.go
+++ b/serial_windows.go
@@ -9,9 +9,13 @@ import (
 	"syscall"
 	"time"
 	"unsafe"
+    "io"
 )
 
 type Port struct {
+    io.Reader
+    io.Writer
+    io.Closer
 	f  *os.File
 	fd syscall.Handle
 	rl sync.Mutex


### PR DESCRIPTION
Since Port already implements the Reader/Writer/Closer methods, adding these interfaces allows Port to be used across other libraries such as bufio.Scanner.