### PR TITLE
Added support for bytesize, stopbits, parity

### DIFF
--- a/serial.go
+++ b/serial.go
@@ -79,9 +79,9 @@ type Config struct {
 	Baud        int
 	ReadTimeout time.Duration // Total timeout
 
-	// Size     int // 0 get translated to 8
-	// Parity   SomeNewTypeToGetCorrectDefaultOf_None
-	// StopBits SomeNewTypeToGetCorrectDefaultOf_1
+	Size     DataBitsType
+	Parity   ParityType
+	StopBits StopBitsType
 
 	// RTSFlowControl bool
 	// DTRFlowControl bool
@@ -92,7 +92,7 @@ type Config struct {
 
 // OpenPort opens a serial port with the specified configuration
 func OpenPort(c *Config) (*Port, error) {
-	return openPort(c.Name, c.Baud, c.ReadTimeout)
+	return openPort(c.Name, c.Baud, byte(c.Size), byte(c.Parity), byte(c.StopBits), c.ReadTimeout)
 }
 
 // Converts the timeout values for Linux / POSIX systems

--- a/serial_constants.go
+++ b/serial_constants.go
@@ -1,0 +1,26 @@
+package serial
+
+type DataBitsType byte
+type StopBitsType byte
+type ParityType byte
+
+const (
+	DATABITS_8 DataBitsType = iota
+	DATABITS_7
+	DATABITS_6
+	DATABITS_5
+)
+
+const (
+	STOPBITS_1 StopBitsType = iota
+	STOPBITS_15
+	STOPBITS_2
+)
+
+const (
+	PARITY_NONE ParityType = iota
+	PARITY_ODD
+	PARITY_EVEN
+	PARITY_MARK
+	PARITY_SPACE
+)

--- a/serial_windows.go
+++ b/serial_windows.go
@@ -179,8 +179,7 @@ func setCommState(h syscall.Handle, baud int, databits byte, parity byte, stopbi
 	params.flags[0] |= 0x10 // Assert DSR
 
 	params.BaudRate = uint32(baud)
-	params.ByteSize = databits
-
+	params.ByteSize = 8-databits
 	params.Parity = parity
 
 	params.StopBits = stopbits

--- a/serial_windows.go
+++ b/serial_windows.go
@@ -37,7 +37,7 @@ type structTimeouts struct {
 	WriteTotalTimeoutConstant   uint32
 }
 
-func openPort(name string, baud int, readTimeout time.Duration) (p *Port, err error) {
+func openPort(name string, baud int, databits byte, parity byte, stopbits byte, readTimeout time.Duration) (p *Port, err error) {
 	if len(name) > 0 && name[0] != '\\' {
 		name = "\\\\.\\" + name
 	}
@@ -59,7 +59,7 @@ func openPort(name string, baud int, readTimeout time.Duration) (p *Port, err er
 		}
 	}()
 
-	if err = setCommState(h, baud); err != nil {
+	if err = setCommState(h, baud, databits, parity, stopbits); err != nil {
 		return
 	}
 	if err = setupComm(h, 64, 64); err != nil {
@@ -171,7 +171,7 @@ func getProcAddr(lib syscall.Handle, name string) uintptr {
 	return addr
 }
 
-func setCommState(h syscall.Handle, baud int) error {
+func setCommState(h syscall.Handle, baud int, databits byte, parity byte, stopbits byte) error {
 	var params structDCB
 	params.DCBlength = uint32(unsafe.Sizeof(params))
 
@@ -179,7 +179,11 @@ func setCommState(h syscall.Handle, baud int) error {
 	params.flags[0] |= 0x10 // Assert DSR
 
 	params.BaudRate = uint32(baud)
-	params.ByteSize = 8
+	params.ByteSize = databits
+
+	params.Parity = parity
+
+	params.StopBits = stopbits
 
 	r, _, err := syscall.Syscall(nSetCommState, 2, uintptr(h), uintptr(unsafe.Pointer(&params)), 0)
 	if r == 0 {


### PR DESCRIPTION
I try to add support for bytesize 5,6,7,8, parity, stopbits.
I tested on windows and it seems to work.
I don't know how to deal with the 1.5 stop bits, so I turn it on-the-fly to 2
I cannot compile the "posix" version so I can't guaranteed about that.
Each new parameter is optional, so the library is retro-compatible and defaulted to 8N1, as requested by the author.