### PR TITLE
Added port list functionality and increased range of baud rates available via serial_posix.go

### DIFF
--- a/serial.go
+++ b/serial.go
@@ -95,28 +95,6 @@ func OpenPort(c *Config) (*Port, error) {
 	return openPort(c.Name, c.Baud, c.ReadTimeout)
 }
 
-// Converts the timeout values for Linux / POSIX systems
-func posixTimeoutValues(readTimeout time.Duration) (vmin uint8, vtime uint8) {
-	const MAXUINT8 = 1<<8 - 1 // 255
-	// set blocking / non-blocking read
-	var minBytesToRead uint8 = 1
-	var readTimeoutInDeci int64
-	if readTimeout > 0 {
-		// EOF on zero read
-		minBytesToRead = 0
-		// convert timeout to deciseconds as expected by VTIME
-		readTimeoutInDeci = (readTimeout.Nanoseconds() / 1e6 / 100)
-		// capping the timeout
-		if readTimeoutInDeci < 1 {
-			// min possible timeout 1 Deciseconds (0.1s)
-			readTimeoutInDeci = 1
-		} else if readTimeoutInDeci > MAXUINT8 {
-			// max possible timeout is 255 deciseconds (25.5s)
-			readTimeoutInDeci = MAXUINT8
-		}
-	}
-	return minBytesToRead, uint8(readTimeoutInDeci)
-}
 
 // func SendBreak()
 

--- a/serial_linux.go
+++ b/serial_linux.go
@@ -6,7 +6,10 @@ import (
 	"os"
 	"syscall"
 	"time"
-	"unsafe"
+	"strings"
+    "unsafe"
+	log "github.com/Sirupsen/logrus"
+	"fmt"
 )
 
 func openPort(name string, baud int, readTimeout time.Duration) (p *Port, err error) {

--- a/serial_posix.go
+++ b/serial_posix.go
@@ -14,7 +14,6 @@ import (
 	"os"
 	"syscall"
 	"time"
-	//"unsafe"
 )
 
 func openPort(name string, baud int, readTimeout time.Duration) (p *Port, err error) {
@@ -35,26 +34,91 @@ func openPort(name string, baud int, readTimeout time.Duration) (p *Port, err er
 		f.Close()
 		return nil, err
 	}
-	var speed C.speed_t
-	switch baud {
-	case 115200:
-		speed = C.B115200
-	case 57600:
-		speed = C.B57600
-	case 38400:
-		speed = C.B38400
-	case 19200:
-		speed = C.B19200
-	case 9600:
-		speed = C.B9600
-	case 4800:
-		speed = C.B4800
-	case 2400:
-		speed = C.B2400
-	default:
-		f.Close()
-		return nil, fmt.Errorf("Unknown baud rate %v", baud)
+
+  var bauds = map[int]C.speed_t{
+		50:      C.B50,
+		75:      C.B75,
+		110:     C.B110,
+		134:     C.B134,
+		150:     C.B150,
+		200:     C.B200,
+		300:     C.B300,
+		600:     C.B600,
+		1200:    C.B1200,
+		1800:    C.B1800,
+		2400:    C.B2400,
+		4800:    C.B4800,
+		9600:    C.B9600,
+		19200:   C.B19200,
+		38400:   C.B38400,
+		57600:   C.B57600,
+		115200:  C.B115200,
+		230400:  C.B230400,
+		460800:  C.B460800,
+		500000:  C.B500000,
+		576000:  C.B576000,
+		921600:  C.B921600,
+		1000000: C.B1000000,
+		1152000: C.B1152000,
+		1500000: C.B1500000,
+		2000000: C.B2000000,
+		2500000: C.B2500000,
+		3000000: C.B3000000,
+		3500000: C.B3500000,
+		4000000: C.B4000000,
 	}
+
+	// var speed C.speed_t
+
+
+	// switch baud {
+	// case 230400:
+	// 	speed = C.B230400
+	// case 115200:
+	// 	speed = C.B115200
+	// case 57600:
+	// 	speed = C.B57600
+	// case 38400:
+	// 	speed = C.B38400
+	// case 19200:
+	// 	speed = C.B19200
+	// case 9600:
+	// 	speed = C.B9600
+	// case 4800:
+	// 	speed = C.B4800
+  // case 2400:
+	// 	speed = C.B2400
+  // case 1800:
+	// 	speed = C.B1800
+  // case 1200:
+	// 	speed = C.B1200
+  // case 600:
+	// 	speed = C.B600
+  // case 300:
+	// 	speed = C.B300
+  // case 200:
+	// 	speed = C.B200
+  // case 150:
+	// 	speed = C.B150
+  // case 134:
+	// 	speed = C.B134
+  // case 110:
+	// 	speed = C.B110
+  // case 75:
+	// 	speed = C.B75
+  // case 50:
+	// 	speed = C.B50
+	// default:
+	// 	f.Close()
+	// 	return nil, fmt.Errorf("Unknown baud rate %v", baud)
+	// }
+
+  speed := bauds[baud]
+
+  if speed == 0 {
+    f.Close()
+  	return nil, fmt.Errorf("Unknown baud rate %v", baud)
+  }
 
 	_, err = C.cfsetispeed(&st, speed)
 	if err != nil {

--- a/serial_x.go
+++ b/serial_x.go
@@ -1,0 +1,116 @@
+// +build !windows
+
+package serial
+
+import (
+	"time"
+	"io/ioutil"
+	"regexp"
+	"strings"
+)
+
+const (
+	devFolder = "/dev"
+	regexFilter = `^(cu|tty)\.?.*`
+)
+
+/*
+This function was taken with minor modifications from the go.bug.st/serial package (https://github.com/bugst/go-serial), and is subject to the conditions of its license (reproduced below):
+
+Copyright (c) 2014, Cristian Maglie.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in
+   the documentation and/or other materials provided with the
+   distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+*/
+func GetPortsList() ([]string, error) {
+	files, err := ioutil.ReadDir(devFolder)
+	if err != nil {
+		return nil, err
+	}
+
+	ports := make([]string, 0, len(files))
+	for _, f := range files {
+		// Skip folders
+		if f.IsDir() {
+			continue
+		}
+
+		// Keep only devices with the correct name
+		match, err := regexp.MatchString(regexFilter, f.Name())
+		if err != nil {
+			return nil, err
+		}
+		if !match {
+			continue
+		}
+
+		portName := devFolder + "/" + f.Name()
+
+		// Check if serial port is real or is a placeholder serial port "ttySxx"
+		if strings.HasPrefix(f.Name(), "ttyS") {
+			port, err := openPort(portName, 9600, 100)
+			if err != nil {
+				continue
+			} else {
+				port.Close()
+			}
+		}
+
+		// Save serial port in the resulting list
+		ports = append(ports, portName)
+	}
+
+	return ports, nil
+}
+
+
+// Converts the timeout values for Linux / POSIX systems
+// Moved to this new source module from serial.go
+func posixTimeoutValues(readTimeout time.Duration) (vmin uint8, vtime uint8) {
+	const MAXUINT8 = 1<<8 - 1 // 255
+	// set blocking / non-blocking read
+	var minBytesToRead uint8 = 1
+	var readTimeoutInDeci int64
+	if readTimeout > 0 {
+		// EOF on zero read
+		minBytesToRead = 0
+		// convert timeout to deciseconds as expected by VTIME
+		readTimeoutInDeci = (readTimeout.Nanoseconds() / 1e6 / 100)
+		// capping the timeout
+		if readTimeoutInDeci < 1 {
+			// min possible timeout 1 Deciseconds (0.1s)
+			readTimeoutInDeci = 1
+		} else if readTimeoutInDeci > MAXUINT8 {
+			// max possible timeout is 255 deciseconds (25.5s)
+			readTimeoutInDeci = MAXUINT8
+		}
+	}
+	return minBytesToRead, uint8(readTimeoutInDeci)
+}


### PR DESCRIPTION
Added GetPortsList method to all implementations, shamelessly lifted 
from the gobug.st/serial package and subject to the conditions of its
BSD-like license (which has been reproduced in source as per terms of said
license). Experienced stability issues with gobug.st ages back, which is
why I switched and stole.

Updated serial_posix to support full list of termios baud rates (as per
existing serial_linux implementation).

Moved posixTimeoutValues method from top level serial.go to new
serial_x.go source file, as only required for linux and posix
implementations.

A major disclaimer -- not retested on windows and OSX since some refactoring and merging upstream changes over the last day or two, as moved office and only have Linux machines to hand.