### PR TITLE
Data, parity, stop bit settings and config parsing and formatting

### DIFF
--- a/basic_test.go
+++ b/basic_test.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package serial
 
 import (

--- a/format.go
+++ b/format.go
@@ -1,0 +1,226 @@
+package serial
+
+import (
+	"strconv"
+	"time"
+)
+
+// ErrParse is the error returned if ParseConfig or ParseSettings have failed.
+type ErrParse string
+
+func (e ErrParse) Error() string { return string(e) }
+
+// ParseConfig parses a config using the template:
+//  <Name> ":" <Baud> "," <Settings> "," <ReadTimeout>
+// Both Settings and ReadTimeout may be omitted, in that
+// case the default values 8-N-1 and 0 will be used.
+// Settings are parsed with ParseSettings.
+// ReadTimeout is parsed using time.ParseDuration().
+func ParseConfig(s string) (*Config, error) {
+	colon := -1
+	var comma []int
+	for i, r := range s {
+		switch r {
+		case ':':
+			colon = i
+			// disregard commas seen so far
+			comma = comma[:0]
+		case ',':
+			if colon >= 0 {
+				comma = append(comma, i)
+			}
+		}
+	}
+	if colon == -1 {
+		return nil, ErrParse("serial.ParseConfig: missing name or colon")
+	}
+
+	// extend comma slice to simplify the code below
+	comma = append(comma, len(s))
+
+	// parse Name and Baud
+	c := &Config{Name: s[:colon]}
+	baud, err := strconv.Atoi(s[colon+1 : comma[0]])
+	if err != nil {
+		return nil, ErrParse("serial.ParseConfig: error parsing baud")
+	}
+	c.Baud = int(baud)
+	if len(comma) == 1 {
+		return c, nil
+	}
+
+	// parse Settings
+	c.Size, c.Parity, c.StopBits, err = ParseSettings(s[comma[0]+1 : comma[1]])
+	if err != nil {
+		return nil, err
+	}
+	if len(comma) == 2 {
+		return c, nil
+	}
+
+	// parse ReadTimeout
+	c.ReadTimeout, err = time.ParseDuration(s[comma[1]+1 : comma[2]])
+	if err != nil {
+		return nil, ErrParse("serial.ParseConfig: bad duration")
+	}
+	if len(comma) == 3 {
+		return c, nil
+	}
+	return nil, ErrParse("serial.ParseConfig: garbage after timeout")
+}
+
+// String formats a config using the template:
+//  <Name> ":" <Baud> "," <Settings> "," <ReadTimeout>
+// Settings are formatted using Config.Settings.
+// ReadTimeout is formatted using time.Duration.String()
+func (c *Config) String() string {
+	// Largest Baud is ±IntMax
+	// Settings is 3 or 5 chars
+	buf := make([]byte, len(c.Name)+1, len(c.Name)+32)
+	copy(buf, c.Name)
+	buf[len(c.Name)] = ':'
+	buf = strconv.AppendInt(buf, int64(c.Baud), 10)
+	buf = append(buf, ',')
+	buf = appendSettings(buf, c.Size, c.Parity, c.StopBits)
+	buf = append(buf, ',')
+	return string(buf) + c.ReadTimeout.String()
+}
+
+// Settings formats data, parity and stop bit
+// settings using FormatSettings.
+func (c *Config) Settings() string {
+	return FormatSettings(c.Size, c.Parity, c.StopBits)
+}
+
+// FormatSettings formats data, parity and stop bits settings
+// using the conventional notation <data> <parity> <stop>
+// with no separator in between.
+func FormatSettings(size byte, par Parity, stop StopBits) string {
+	return string(appendSettings(make([]byte, 0, 8), size, par, stop))
+}
+
+func appendSettings(p []byte, size byte, par Parity, stop StopBits) []byte {
+	// size
+	if size == 0 {
+		size = DefaultSize
+	}
+	if size < 9 {
+		p = append(p, '0'+size)
+	} else {
+		p = append(p, '9')
+	}
+
+	// parity
+	if par == 0 {
+		par = ParityNone
+	}
+	p = append(p, byte(par))
+
+	// stop bit
+	if stop == 0 {
+		stop = Stop1
+	}
+	switch stop {
+	case Stop1:
+		p = append(p, '1')
+	case Stop2:
+		p = append(p, '2')
+	case Stop1Half:
+		p = append(p, '1', '.', '5')
+	default:
+		p = append(p, '9')
+	}
+
+	return p
+}
+
+// ParseSettings parses data, parity and stop bits settings.
+// It accepts either '-' or '/' as separator, or no separator.
+func ParseSettings(s string) (size byte, parity Parity, stop StopBits, err error) {
+	size, parity, stop = DefaultSize, ParityNone, Stop1
+	if s == "" {
+		return size, parity, stop, nil
+	}
+
+	// parse data bits
+	p := 0
+	c := s[p]
+	p++
+	if c < '1' || '8' < c {
+		return size, parity, stop, ErrParse("serial.ParseSettings: invalid data size")
+	}
+	size = c - '0'
+
+	// parse parity
+	if p == len(s) {
+		return size, parity, stop, ErrParse("serial.ParseSettings: invalid input")
+	}
+	c = s[p]
+	p++
+	var sep byte
+	if !isalnum(c) {
+		if c != '-' && c != '/' {
+			return size, parity, stop, ErrParse("serial.ParseSettings: mismatched separator")
+		}
+		// store and skip separator
+		sep = c
+		if p == len(s) {
+			return size, parity, stop, ErrParse("serial.ParseSettings: invalid input")
+		}
+		c = s[p]
+		p++
+	}
+	switch c {
+	case 'n', 'o', 'e', 'm', 's':
+		c -= 'a' - 'A' // convert to uppercase
+	case 'N', 'O', 'E', 'M', 'S':
+		// pass
+	default:
+		return size, parity, stop, ErrParse("serial.ParseSettings: invalid parity")
+	}
+	parity = Parity(c)
+
+	// parse stop bits
+	if p == len(s) {
+		return size, parity, stop, ErrParse("serial.ParseSettings: invalid input")
+	}
+	c = s[p]
+	p++
+	if sep != 0 {
+		// compare and skip separator
+		if c != sep || p == len(s) {
+			return size, parity, stop, ErrParse("serial.ParseSettings: bad separator")
+		}
+		c = s[p]
+		p++
+	}
+	switch {
+	case endnum(s[p:]) && (c == '1' || c == '2'):
+		if c == '1' {
+			stop = Stop1
+		} else {
+			stop = Stop2
+		}
+	case c == '1' && (p+2 <= len(s) && s[p] == '.' && s[p+1] == '5' && endnum(s[p+2:])):
+		stop = Stop1Half
+		p += 2
+	default:
+		return size, parity, stop, ErrParse("serial.ParseSettings: invalid stop bits")
+	}
+
+	if p != len(s) {
+		return size, parity, stop, ErrParse("serial.ParseSettings: garbage after input")
+	}
+	return size, parity, stop, nil
+}
+
+func isalnum(c byte) bool {
+	return ('A' <= c && c <= 'Z') || ('a' <= c && c <= 'z') || ('0' <= c && c <= '9')
+}
+
+func endnum(s string) bool {
+	if len(s) == 0 {
+		return true
+	}
+	return s[0] != '.' && !('0' <= s[0] && s[0] <= '9')
+}

--- a/format_test.go
+++ b/format_test.go
@@ -1,0 +1,126 @@
+package serial
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseConfig(t *testing.T) {
+	for _, x := range []struct {
+		in   string
+		name string
+		baud int
+		siz  byte
+		par  Parity
+		stop StopBits
+		rto  string
+		msg  string
+	}{
+		{"/dev/ttyUSB0:9600,8N1,500ms", "/dev/ttyUSB0", 9600, 8, ParityNone, Stop1, "500ms", ""},
+		{"COM1:2400,8N1,1s", "COM1", 2400, 8, ParityNone, Stop1, "1s", ""},
+		{"COM1::19200,7-E-1,0", "COM1:", 19200, 7, ParityEven, Stop1, "0", ""},
+
+		// strange port name with comma in it
+		{"portname,with,comma:19200,7o2,0", "portname,with,comma", 19200, 7, ParityOdd, Stop2, "0", ""},
+
+		{in: "/dev/ttyUSB0", msg: "serial.ParseConfig: missing name or colon"},
+		{in: "/dev/ttyUSB0:0x800,8N1,500ms", msg: "serial.ParseConfig: error parsing baud"},
+		{in: "/dev/ttyUSB0:4800,6E2,500", msg: "serial.ParseConfig: bad duration"},
+		{in: "/dev/ttyUSB0:4800,8E2,500ms,extra", msg: "serial.ParseConfig: garbage after timeout"},
+	} {
+		c, err := ParseConfig(x.in)
+		if err != nil {
+			if x.msg == "" {
+				t.Error(x.in, "got error:", err.Error())
+			} else if err.Error() != x.msg {
+				t.Error(x.in, "got error:", err.Error(), "want:", x.msg)
+			}
+		} else {
+			if x.msg != "" {
+				t.Error(x.in, "worked but wanted error:", x.msg)
+			} else {
+				rto, err := time.ParseDuration(x.rto)
+				if err != nil {
+					t.Fatal(err)
+				}
+				xc := Config{
+					Name:     x.name,
+					Baud:     x.baud,
+					Size:     x.siz,
+					Parity:   x.par,
+					StopBits: x.stop,
+
+					ReadTimeout: rto,
+				}
+				if *c != xc {
+					t.Error(x.in, "mismatch:", c, "!=", xc)
+				}
+			}
+		}
+	}
+}
+
+func TestFormatSettings(t *testing.T) {
+	for _, x := range []struct {
+		siz  byte
+		par  Parity
+		stop StopBits
+		want string
+	}{
+		{8, ParityNone, Stop1, "8N1"},
+		{7, ParityEven, Stop1, "7E1"},
+		{7, ParityEven, Stop1Half, "7E1.5"},
+		{5, ParityOdd, Stop1Half, "5O1.5"},
+	} {
+		s := FormatSettings(x.siz, x.par, x.stop)
+		if s != x.want {
+			t.Error("got: ", s, " want: ", x.want)
+		}
+	}
+}
+
+func TestParseSettings(t *testing.T) {
+	for _, x := range []struct {
+		in string
+
+		siz  byte
+		par  Parity
+		stop StopBits
+
+		msg string
+	}{
+		{"8N1", 8, ParityNone, Stop1, ""},
+		{"8-N-1", 8, ParityNone, Stop1, ""},
+		{"8/N/1", 8, ParityNone, Stop1, ""},
+		{"8/n/1", 8, ParityNone, Stop1, ""},
+		{"8/N-1", 8, ParityNone, Stop1, "serial.ParseSettings: bad separator"},
+		{"8,N,1", 8, ParityNone, Stop1, "serial.ParseSettings: mismatched separator"},
+		{"8-N-1-x", 8, ParityNone, Stop1, "serial.ParseSettings: garbage after input"},
+		{"7-E-1", 7, ParityEven, Stop1, ""},
+		{"7-E-2", 7, ParityEven, Stop2, ""},
+		{"7-e-2", 7, ParityEven, Stop2, ""},
+		{"7-Z-1", 7, ParityEven, Stop1, "serial.ParseSettings: invalid parity"},
+		{"5O1.5", 5, ParityOdd, Stop1Half, ""},
+		{"5o1.5", 5, ParityOdd, Stop1Half, ""},
+		{"5O1.6", 5, ParityOdd, Stop1Half, "serial.ParseSettings: invalid stop bits"},
+		{"5O2.5", 5, ParityOdd, Stop1Half, "serial.ParseSettings: invalid stop bits"},
+		{"5O23", 5, ParityOdd, Stop1Half, "serial.ParseSettings: invalid stop bits"},
+	} {
+		siz, par, stop, err := ParseSettings(x.in)
+		if err != nil {
+			if x.msg == "" {
+				t.Error(x.in, "got error:", err.Error())
+			} else if err.Error() != x.msg {
+				t.Error(x.in, "got error:", err.Error(), "want:", x.msg)
+			}
+		} else {
+			if x.msg != "" {
+				t.Error(x.in, "worked but wanted error:", x.msg)
+			}
+			if siz != x.siz || par != x.par || stop != x.stop {
+				t.Error(x.in, "got:", siz, string([]byte{byte(par)}), stop,
+					"want:", x.siz, string([]byte{byte(x.par)}), x.stop)
+			}
+		}
+	}
+}

--- a/serial_linux.go
+++ b/serial_linux.go
@@ -9,7 +9,7 @@ import (
 	"unsafe"
 )
 
-func openPort(name string, baud int, readTimeout time.Duration) (p *Port, err error) {
+func openPort(name string, baud int, databits byte, parity Parity, stopbits StopBits, readTimeout time.Duration) (p *Port, err error) {
 	var bauds = map[int]uint32{
 		50:      syscall.B50,
 		75:      syscall.B75,
@@ -60,11 +60,47 @@ func openPort(name string, baud int, readTimeout time.Duration) (p *Port, err er
 		}
 	}()
 
+	// Base settings
+	cflagToUse := syscall.CREAD | syscall.CLOCAL | rate
+	switch databits {
+	case 5:
+		cflagToUse |= syscall.CS5
+	case 6:
+		cflagToUse |= syscall.CS6
+	case 7:
+		cflagToUse |= syscall.CS7
+	case 8:
+		cflagToUse |= syscall.CS8
+	default:
+		return nil, ErrBadSize
+	}
+	// Stop bits settings
+	switch stopbits {
+	case Stop1:
+		// default is 1 stop bit
+	case Stop2:
+		cflagToUse |= syscall.CSTOPB
+	default:
+		// Don't know how to set 1.5
+		return nil, ErrBadStopBits
+	}
+	// Parity settings
+	switch parity {
+	case ParityNone:
+		// default is no parity
+	case ParityOdd:
+		cflagToUse |= syscall.PARENB
+		cflagToUse |= syscall.PARODD
+	case ParityEven:
+		cflagToUse |= syscall.PARENB
+	default:
+		return nil, ErrBadParity
+	}
 	fd := f.Fd()
 	vmin, vtime := posixTimeoutValues(readTimeout)
 	t := syscall.Termios{
 		Iflag:  syscall.IGNPAR,
-		Cflag:  syscall.CS8 | syscall.CREAD | syscall.CLOCAL | rate,
+		Cflag:  cflagToUse,
 		Cc:     [32]uint8{syscall.VMIN: vmin, syscall.VTIME: vtime},
 		Ispeed: rate,
 		Ospeed: rate,

--- a/serial_windows.go
+++ b/serial_windows.go
@@ -60,25 +60,25 @@ func openPort(name string, baud int, databits byte, parity Parity, stopbits Stop
 	}()
 
 	if err = setCommState(h, baud, databits, parity, stopbits); err != nil {
-		return
+		return nil, err
 	}
 	if err = setupComm(h, 64, 64); err != nil {
-		return
+		return nil, err
 	}
 	if err = setCommTimeouts(h, readTimeout); err != nil {
-		return
+		return nil, err
 	}
 	if err = setCommMask(h); err != nil {
-		return
+		return nil, err
 	}
 
 	ro, err := newOverlapped()
 	if err != nil {
-		return
+		return nil, err
 	}
 	wo, err := newOverlapped()
 	if err != nil {
-		return
+		return nil, err
 	}
 	port := new(Port)
 	port.f = f


### PR DESCRIPTION
The first commit is the PR #34 from @paocalvi squashed and cleaned up to use the go naming convention. It return errors for unsupported configuration instead of using defaults.

The second commit replaces naked returns to use arguments in some function(s). Naked returns should be used only in short functions.

The third commit just adds a build tag so that I could test format.go on windows.

The fourth commit adds code to format and parse serial configurations, useful for command line argument handling.