### PR TITLE
serial_posix: fix even parity

### DIFF
--- a/serial_posix.go
+++ b/serial_posix.go
@@ -113,6 +113,7 @@ func openPort(name string, baud int, databits byte, parity Parity, stopbits Stop
 		st.c_cflag |= C.PARODD
 	case ParityEven:
 		st.c_cflag |= C.PARENB
+		st.c_cflag &= ^C.tcflag_t(C.PARODD)
 	default:
 		return nil, ErrBadParity
 	}


### PR DESCRIPTION
Previously, when even parity was requested, PARODD was erroneously retained, and thus could actually result in odd parity being set (retained from what was set by tcgetattr)