### PR TITLE
serial_linux/posix: don't use _posix if cgo is enabled on linux

### DIFF
--- a/serial_linux.go
+++ b/serial_linux.go
@@ -1,4 +1,4 @@
-// +build linux,!cgo
+// +build linux
 
 package serial
 

--- a/serial_posix.go
+++ b/serial_posix.go
@@ -1,4 +1,4 @@
-// +build !windows,cgo
+// +build !windows,!linux,cgo
 
 package serial
 


### PR DESCRIPTION
Setting linux-compatible baudrates (like 1Mbaud) does not work using
_posix.