### PR TITLE
Use "golang.org/x/sys/unix" instead of "syscall" (fix #59)

### DIFF
--- a/serial_linux.go
+++ b/serial_linux.go
@@ -4,43 +4,44 @@ package serial
 
 import (
 	"os"
-	"syscall"
 	"time"
 	"unsafe"
+
+	"golang.org/x/sys/unix"
 )
 
 func openPort(name string, baud int, databits byte, parity Parity, stopbits StopBits, readTimeout time.Duration) (p *Port, err error) {
 	var bauds = map[int]uint32{
-		50:      syscall.B50,
-		75:      syscall.B75,
-		110:     syscall.B110,
-		134:     syscall.B134,
-		150:     syscall.B150,
-		200:     syscall.B200,
-		300:     syscall.B300,
-		600:     syscall.B600,
-		1200:    syscall.B1200,
-		1800:    syscall.B1800,
-		2400:    syscall.B2400,
-		4800:    syscall.B4800,
-		9600:    syscall.B9600,
-		19200:   syscall.B19200,
-		38400:   syscall.B38400,
-		57600:   syscall.B57600,
-		115200:  syscall.B115200,
-		230400:  syscall.B230400,
-		460800:  syscall.B460800,
-		500000:  syscall.B500000,
-		576000:  syscall.B576000,
-		921600:  syscall.B921600,
-		1000000: syscall.B1000000,
-		1152000: syscall.B1152000,
-		1500000: syscall.B1500000,
-		2000000: syscall.B2000000,
-		2500000: syscall.B2500000,
-		3000000: syscall.B3000000,
-		3500000: syscall.B3500000,
-		4000000: syscall.B4000000,
+		50:      unix.B50,
+		75:      unix.B75,
+		110:     unix.B110,
+		134:     unix.B134,
+		150:     unix.B150,
+		200:     unix.B200,
+		300:     unix.B300,
+		600:     unix.B600,
+		1200:    unix.B1200,
+		1800:    unix.B1800,
+		2400:    unix.B2400,
+		4800:    unix.B4800,
+		9600:    unix.B9600,
+		19200:   unix.B19200,
+		38400:   unix.B38400,
+		57600:   unix.B57600,
+		115200:  unix.B115200,
+		230400:  unix.B230400,
+		460800:  unix.B460800,
+		500000:  unix.B500000,
+		576000:  unix.B576000,
+		921600:  unix.B921600,
+		1000000: unix.B1000000,
+		1152000: unix.B1152000,
+		1500000: unix.B1500000,
+		2000000: unix.B2000000,
+		2500000: unix.B2500000,
+		3000000: unix.B3000000,
+		3500000: unix.B3500000,
+		4000000: unix.B4000000,
 	}
 
 	rate := bauds[baud]
@@ -49,7 +50,7 @@ func openPort(name string, baud int, databits byte, parity Parity, stopbits Stop
 		return
 	}
 
-	f, err := os.OpenFile(name, syscall.O_RDWR|syscall.O_NOCTTY|syscall.O_NONBLOCK, 0666)
+	f, err := os.OpenFile(name, unix.O_RDWR|unix.O_NOCTTY|unix.O_NONBLOCK, 0666)
 	if err != nil {
 		return nil, err
 	}
@@ -61,16 +62,16 @@ func openPort(name string, baud int, databits byte, parity Parity, stopbits Stop
 	}()
 
 	// Base settings
-	cflagToUse := syscall.CREAD | syscall.CLOCAL | rate
+	cflagToUse := unix.CREAD | unix.CLOCAL | rate
 	switch databits {
 	case 5:
-		cflagToUse |= syscall.CS5
+		cflagToUse |= unix.CS5
 	case 6:
-		cflagToUse |= syscall.CS6
+		cflagToUse |= unix.CS6
 	case 7:
-		cflagToUse |= syscall.CS7
+		cflagToUse |= unix.CS7
 	case 8:
-		cflagToUse |= syscall.CS8
+		cflagToUse |= unix.CS8
 	default:
 		return nil, ErrBadSize
 	}
@@ -79,7 +80,7 @@ func openPort(name string, baud int, databits byte, parity Parity, stopbits Stop
 	case Stop1:
 		// default is 1 stop bit
 	case Stop2:
-		cflagToUse |= syscall.CSTOPB
+		cflagToUse |= unix.CSTOPB
 	default:
 		// Don't know how to set 1.5
 		return nil, ErrBadStopBits
@@ -89,27 +90,28 @@ func openPort(name string, baud int, databits byte, parity Parity, stopbits Stop
 	case ParityNone:
 		// default is no parity
 	case ParityOdd:
-		cflagToUse |= syscall.PARENB
-		cflagToUse |= syscall.PARODD
+		cflagToUse |= unix.PARENB
+		cflagToUse |= unix.PARODD
 	case ParityEven:
-		cflagToUse |= syscall.PARENB
+		cflagToUse |= unix.PARENB
 	default:
 		return nil, ErrBadParity
 	}
 	fd := f.Fd()
 	vmin, vtime := posixTimeoutValues(readTimeout)
-	t := syscall.Termios{
-		Iflag:  syscall.IGNPAR,
+	t := unix.Termios{
+		Iflag:  unix.IGNPAR,
 		Cflag:  cflagToUse,
-		Cc:     [32]uint8{syscall.VMIN: vmin, syscall.VTIME: vtime},
 		Ispeed: rate,
 		Ospeed: rate,
 	}
+	t.Cc[unix.VMIN] = vmin
+	t.Cc[unix.VTIME] = vtime
 
-	if _, _, errno := syscall.Syscall6(
-		syscall.SYS_IOCTL,
+	if _, _, errno := unix.Syscall6(
+		unix.SYS_IOCTL,
 		uintptr(fd),
-		uintptr(syscall.TCSETS),
+		uintptr(unix.TCSETS),
 		uintptr(unsafe.Pointer(&t)),
 		0,
 		0,
@@ -118,7 +120,7 @@ func openPort(name string, baud int, databits byte, parity Parity, stopbits Stop
 		return nil, errno
 	}
 
-	if err = syscall.SetNonblock(int(fd), false); err != nil {
+	if err = unix.SetNonblock(int(fd), false); err != nil {
 		return
 	}
 
@@ -143,11 +145,11 @@ func (p *Port) Write(b []byte) (n int, err error) {
 // or data received but not read
 func (p *Port) Flush() error {
 	const TCFLSH = 0x540B
-	_, _, errno := syscall.Syscall(
-		syscall.SYS_IOCTL,
+	_, _, errno := unix.Syscall(
+		unix.SYS_IOCTL,
 		uintptr(p.f.Fd()),
 		uintptr(TCFLSH),
-		uintptr(syscall.TCIOFLUSH),
+		uintptr(unix.TCIOFLUSH),
 	)
 
 	if errno == 0 {


### PR DESCRIPTION
According to the discussion on golang/go#18866, `Termios` from `golang.org/x/sys/unix` has better portability than `syscall.Termios`. So we should use it.

This PR works fine on mipsle.