### PR TITLE
Remove unused references to syscall.Termios.{Ispeed,Ospeed}

### DIFF
--- a/serial_linux.go
+++ b/serial_linux.go
@@ -102,8 +102,6 @@ func openPort(name string, baud int, databits byte, parity Parity, stopbits Stop
 	t := unix.Termios{
 		Iflag:  unix.IGNPAR,
 		Cflag:  cflagToUse,
-		Ispeed: rate,
-		Ospeed: rate,
 	}
 	t.Cc[unix.VMIN] = vmin
 	t.Cc[unix.VTIME] = vtime


### PR DESCRIPTION
This (in combination with #73 ) fixes build on mips and mipsle #59. These struct members aren't referenced anywhere else in the code.