### PR TITLE
TCFLSH should use portable variable

### DIFF
--- a/serial_linux.go
+++ b/serial_linux.go
@@ -144,11 +144,10 @@ func (p *Port) Write(b []byte) (n int, err error) {
 // Discards data written to the port but not transmitted,
 // or data received but not read
 func (p *Port) Flush() error {
-	const TCFLSH = 0x540B
 	_, _, errno := unix.Syscall(
 		unix.SYS_IOCTL,
 		uintptr(p.f.Fd()),
-		uintptr(TCFLSH),
+		uintptr(unix.TCFLSH),
 		uintptr(unix.TCIOFLUSH),
 	)
 


### PR DESCRIPTION
TCFLSH for ppc64 and mips is 0x5407. Get rid of hard code here.