### PR TITLE
Having 0x10 set causes arduino to reset when serial message is sent

### DIFF
--- a/serial_windows.go
+++ b/serial_windows.go
@@ -176,7 +176,7 @@ func setCommState(h syscall.Handle, baud int, databits byte, parity Parity, stop
 	params.DCBlength = uint32(unsafe.Sizeof(params))
 
 	params.flags[0] = 0x01  // fBinary
-	params.flags[0] |= 0x10 // Assert DSR
+	//params.flags[0] |= 0x10 // Assert DSR
 
 	params.BaudRate = uint32(baud)
 


### PR DESCRIPTION
Not sure if you want this as a default behavior, but submitting pull request just in case. 

Best Regards,
Michael Mendelson